### PR TITLE
add riemann stats output

### DIFF
--- a/cmd/templar/templar.go
+++ b/cmd/templar/templar.go
@@ -7,12 +7,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/amir/raidman"
 	"github.com/quipo/statsd"
 	"github.com/vektra/templar"
 )
 
 var fDebug = flag.Bool("debug", false, "show debugging info")
 var fStatsd = flag.String("statsd", "", "address to sends statsd stats")
+var fRiemann = flag.String("riemann", "", "address to sends riemann stats")
 var fExpire = flag.Duration("expire", 5*time.Minute, "how long to use cached values")
 
 var fMemcache = flag.String("memcache", "", "memcache servers to use for caching")
@@ -38,6 +40,15 @@ func main() {
 		}
 
 		stats = append(stats, templar.NewStatsdOutput(client))
+	}
+
+	if *fRiemann != "" {
+		client, err := raidman.Dial("tcp", *fRiemann)
+		if err != nil {
+			panic(err)
+		}
+
+		stats = append(stats, templar.NewRiemannOutput(client))
 	}
 
 	categorizer := templar.NewCategorizer()

--- a/cmd/templar/templar.go
+++ b/cmd/templar/templar.go
@@ -14,7 +14,7 @@ import (
 
 var fDebug = flag.Bool("debug", false, "show debugging info")
 var fStatsd = flag.String("statsd", "", "address to sends statsd stats")
-var fRiemann = flag.String("riemann", "", "address to sends riemann stats")
+var fRiemann = flag.String("riemann", "", "address to sends riemann stats over tcp (e.g. localhost:5555)")
 var fExpire = flag.Duration("expire", 5*time.Minute, "how long to use cached values")
 
 var fMemcache = flag.String("memcache", "", "memcache servers to use for caching")

--- a/interfaces.go
+++ b/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"time"
+	"github.com/amir/raidman"
 )
 
 type Responder interface {
@@ -42,4 +43,8 @@ type StatsdClient interface {
 	Incr(name string, count int64) error
 	GaugeDelta(name string, delta int64) error
 	PrecisionTiming(name string, t time.Duration) error
+}
+
+type RiemannClient interface {
+    Send(* raidman.Event) error
 }

--- a/mock_RiemannClient.go
+++ b/mock_RiemannClient.go
@@ -1,0 +1,13 @@
+package templar
+
+import "github.com/stretchr/testify/mock"
+import "github.com/amir/raidman"
+
+type MockRiemannClient struct {
+    mock.Mock
+}
+
+func (r *MockRiemannClient) Send(e *raidman.Event) error {
+    r.Called(e)
+    return nil
+}

--- a/stats_test.go
+++ b/stats_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/vektra/neko"
+	"github.com/amir/raidman"
 )
 
 func TestStatsdOutput(t *testing.T) {
@@ -59,6 +60,85 @@ func TestStatsdOutput(t *testing.T) {
 
 		output.RequestTimeout(req, t)
 
+	})
+
+	n.Meow()
+}
+
+func TestRiemannOutput(t *testing.T) {
+	n := neko.Start(t)
+
+	var (
+		output *RiemannOutput
+		client MockRiemannClient
+	)
+
+	n.CheckMock(&client.Mock)
+
+	n.Setup(func() {
+		output = NewRiemannOutput(&client)
+	})
+
+	n.It("emits stats about a request on start", func() {
+		req, err := http.NewRequest("GET", "http://google.com/foo/bar", nil)
+		require.NoError(t, err)
+
+
+        attributes := make(map[string]string)
+        attributes["method"] = "GET"
+        attributes["host"] = "google.com"
+        attributes["path"] = "/foo/bar"
+        var event = &raidman.Event{
+            State:      "ok",
+            Service:    "templar request",
+            Metric:     1,
+            Attributes: attributes,
+        }
+		client.On("Send", event).Return(nil)
+
+		output.StartRequest(req)
+	})
+
+	n.It("emits stats about a request on end", func() {
+		req, err := http.NewRequest("GET", "http://google.com/foo/bar", nil)
+		require.NoError(t, err)
+
+		t := 1 * time.Second
+
+        attributes := make(map[string]string)
+        attributes["method"] = "GET"
+        attributes["host"] = "google.com"
+        attributes["path"] = "/foo/bar"
+        var event = &raidman.Event{
+            State:      "ok",
+            Service:    "templar response",
+            Metric:     1000.0,
+            Attributes: attributes,
+        }
+		client.On("Send", event).Return(nil)
+
+		output.Emit(req, t)
+	})
+
+	n.It("emits stats when a request times out", func() {
+		req, err := http.NewRequest("GET", "http://google.com/foo/bar", nil)
+		require.NoError(t, err)
+
+		t := 5 * time.Second
+
+        attributes := make(map[string]string)
+        attributes["method"] = "GET"
+        attributes["host"] = "google.com"
+        attributes["path"] = "/foo/bar"
+        var event = &raidman.Event{
+            State:      "warning",
+            Service:    "templar timeout",
+            Metric:     5000.0,
+            Attributes: attributes,
+        }
+		client.On("Send", event).Return(nil)
+
+		output.RequestTimeout(req, t)
 	})
 
 	n.Meow()


### PR DESCRIPTION
outputs 3 kinds of events to riemann, using the optional attributes map
to send information about the request. Services (which is what riemann calls the event name):

`templar request`
`templar response`
`templar timeout`

Uses raidman (https://github.com/amir/raidman) as the underlying riemann
client.
