### PR TITLE
Add Groupcache Cache Backend

### DIFF
--- a/cache/groupcache.go
+++ b/cache/groupcache.go
@@ -6,36 +6,58 @@ import (
 	"github.com/golang/groupcache"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 )
 
+type Transport interface {
+	RoundTrip(*http.Request) (*http.Response, error)
+}
+
 type GroupCacheCache struct {
 	g groupcache.Group
-	t http.Transport
+	t Transport
 }
 
-type cachedRequest struct {
-	body    []byte
-	status  int
-	headers http.Header
+type cachedResponse struct {
+	Body    []byte
+	Status  int
+	Headers http.Header
 }
 
-func NewGroupCacheCache(urls string, defaultExpiration time.Duration, transport http.Transport) *GroupCacheCache {
-	peers := groupcache.NewHTTPPool("localhost:8080")
-	peers.Set("localhost:8081")
+func NewGroupCacheCache(thisPeerURL string, otherPeersURLs string, defaultExpiration time.Duration, transport Transport) *GroupCacheCache {
+	otherPeers := strings.Split(otherPeersURLs, ",")
+	pool := groupcache.NewHTTPPool(thisPeerURL)
+	pool.Set(otherPeers...)
 	getter := func(context groupcache.Context, k string, destination groupcache.Sink) error {
-		req, ok := context.(http.Request)
+		req, ok := context.(*http.Request)
 		if !ok {
 			return errors.New("failed to cast groupcache context to an http request")
 		}
 
-		upstream, err := transport.RoundTrip(&req)
+		upstream, err := transport.RoundTrip(req)
+		if err != nil {
+			return err
+		}
+		body, err := ioutil.ReadAll(upstream.Body)
+		if err != nil {
+			return err
+		}
+		toCache := &cachedResponse{
+			Body:    body,
+			Status:  upstream.StatusCode,
+			Headers: upstream.Header,
+		}
 
-		destination.SetBytes()
+		b, err := Serialize(toCache)
+		if err != nil {
+			return err
+		}
+		destination.SetBytes(b)
 		return nil
 	}
-	group := groupcache.NewGroup("templar", 250, groupcache.GetterFunc(getter))
-	return &GroupCacheCache{*group}
+	group := groupcache.NewGroup("templar", 64<<20, groupcache.GetterFunc(getter))
+	return &GroupCacheCache{*group, transport}
 }
 
 func (c *GroupCacheCache) Set(req *http.Request, resp *http.Response) {
@@ -46,24 +68,23 @@ func (c *GroupCacheCache) Set(req *http.Request, resp *http.Response) {
 }
 
 func (c *GroupCacheCache) Get(req *http.Request) (*http.Response, bool) {
-	var context groupcache.Context = req
 	var data []byte
-	err := c.g.Get(context, req.URL.Path, groupcache.AllocatingByteSliceSink(&data))
+	err := c.g.Get(req, req.URL.Path, groupcache.AllocatingByteSliceSink(&data))
 	if err != nil {
-		return nil, true
+		return nil, false
 	} else {
-		cr := &cachedRequest{}
+		cr := &cachedResponse{}
 		Deserialize(data, cr)
 		resp := &http.Response{
-			StatusCode: cr.status,
+			StatusCode: cr.Status,
 			Header:     make(http.Header),
 		}
-		for k, v := range cr.headers {
+		for k, v := range cr.Headers {
 			resp.Header[k] = v
 		}
 
-		resp.Body = ioutil.NopCloser(bytes.NewReader(cr.body))
+		resp.Body = ioutil.NopCloser(bytes.NewReader(cr.Body))
 
-		return resp, false
+		return resp, true
 	}
 }

--- a/cache/groupcache.go
+++ b/cache/groupcache.go
@@ -1,0 +1,69 @@
+package cache
+
+import (
+	"bytes"
+	"errors"
+	"github.com/golang/groupcache"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+type GroupCacheCache struct {
+	g groupcache.Group
+	t http.Transport
+}
+
+type cachedRequest struct {
+	body    []byte
+	status  int
+	headers http.Header
+}
+
+func NewGroupCacheCache(urls string, defaultExpiration time.Duration, transport http.Transport) *GroupCacheCache {
+	peers := groupcache.NewHTTPPool("localhost:8080")
+	peers.Set("localhost:8081")
+	getter := func(context groupcache.Context, k string, destination groupcache.Sink) error {
+		req, ok := context.(http.Request)
+		if !ok {
+			return errors.New("failed to cast groupcache context to an http request")
+		}
+
+		upstream, err := transport.RoundTrip(&req)
+
+		destination.SetBytes()
+		return nil
+	}
+	group := groupcache.NewGroup("templar", 250, groupcache.GetterFunc(getter))
+	return &GroupCacheCache{*group}
+}
+
+func (c *GroupCacheCache) Set(req *http.Request, resp *http.Response) {
+	// intentionally does nothing:
+	// groupcache doesn't support sets - just reads
+	// as such, we don't support sets, and gets go through a fallback
+	// to an underlying http transport
+}
+
+func (c *GroupCacheCache) Get(req *http.Request) (*http.Response, bool) {
+	var context groupcache.Context = req
+	var data []byte
+	err := c.g.Get(context, req.URL.Path, groupcache.AllocatingByteSliceSink(&data))
+	if err != nil {
+		return nil, true
+	} else {
+		cr := &cachedRequest{}
+		Deserialize(data, cr)
+		resp := &http.Response{
+			StatusCode: cr.status,
+			Header:     make(http.Header),
+		}
+		for k, v := range cr.headers {
+			resp.Header[k] = v
+		}
+
+		resp.Body = ioutil.NopCloser(bytes.NewReader(cr.body))
+
+		return resp, false
+	}
+}

--- a/cache/groupcache.go
+++ b/cache/groupcache.go
@@ -30,7 +30,7 @@ type cachedResponse struct {
 	Headers http.Header
 }
 
-func NewGroupCacheCache(thisPeerAddress string, otherPeersURLs string, defaultExpiration time.Duration, transport Transport) *GroupCacheCache {
+func NewGroupCacheCache(thisPeerAddress string, otherPeersURLs string, defaultExpiration time.Duration, memoryLimit int64, transport Transport) *GroupCacheCache {
 	data := []string{"http://" + thisPeerAddress}
 	otherPeers := append(data, strings.Split(otherPeersURLs, ",")...)
 	pool := groupcache.NewHTTPPool("http://" + thisPeerAddress)
@@ -62,7 +62,7 @@ func NewGroupCacheCache(thisPeerAddress string, otherPeersURLs string, defaultEx
 		destination.SetBytes(b)
 		return nil
 	}
-	group := groupcache.NewGroup("templar", 64<<20, groupcache.GetterFunc(getter))
+	group := groupcache.NewGroup("templar", memoryLimit, groupcache.GetterFunc(getter))
 	go func() {
 		http.ListenAndServe(thisPeerAddress, http.HandlerFunc(pool.ServeHTTP))
 	}()

--- a/cache_backend.go
+++ b/cache_backend.go
@@ -31,6 +31,10 @@ func NewRedisCache(host string, password string, expire time.Duration) *Cache {
 	}
 }
 
+func NewGroupCacheCache(urls string, defaultExpiration time.Duration) *cache.GroupCacheCache {
+	return cache.NewGroupCacheCache(urls, defaultExpiration)
+}
+
 type cachedRequest struct {
 	body    []byte
 	status  int

--- a/cache_backend.go
+++ b/cache_backend.go
@@ -31,8 +31,8 @@ func NewRedisCache(host string, password string, expire time.Duration) *Cache {
 	}
 }
 
-func NewGroupCacheCache(urls string, defaultExpiration time.Duration) *cache.GroupCacheCache {
-	return cache.NewGroupCacheCache(urls, defaultExpiration)
+func NewGroupCacheCache(thisPeerURL string, otherPeersURLs string, defaultExpiration time.Duration, transport Transport) *cache.GroupCacheCache {
+	return cache.NewGroupCacheCache(thisPeerURL, otherPeersURLs, defaultExpiration, transport)
 }
 
 type cachedRequest struct {

--- a/cache_backend.go
+++ b/cache_backend.go
@@ -31,8 +31,8 @@ func NewRedisCache(host string, password string, expire time.Duration) *Cache {
 	}
 }
 
-func NewGroupCacheCache(thisPeerURL string, otherPeersURLs string, defaultExpiration time.Duration, transport Transport) *cache.GroupCacheCache {
-	return cache.NewGroupCacheCache(thisPeerURL, otherPeersURLs, defaultExpiration, transport)
+func NewGroupCacheCache(thisPeerURL string, otherPeersURLs string, defaultExpiration time.Duration, memoryLimit int64, transport Transport) *cache.GroupCacheCache {
+	return cache.NewGroupCacheCache(thisPeerURL, otherPeersURLs, defaultExpiration, memoryLimit, transport)
 }
 
 type cachedRequest struct {

--- a/cmd/templar/templar.go
+++ b/cmd/templar/templar.go
@@ -21,6 +21,7 @@ var fRedis = flag.String("redis", "", "redis server to use for caching")
 var fRedisPassword = flag.String("redis-password", "", "password to redis server")
 var fGroupCacheThisPeer = flag.String("groupcache-this-peer", "", "groupcache peer url to use for this peer")
 var fGroupCacheOtherPeers = flag.String("groupcache-other-peers", "", "groupcache peer url set to use for caching (comma separated)")
+var fGroupCacheMemoryLimit = flag.Int("groupcache-other-peers", 64<<20, "the memory limit to pass to groupcache. Defaults to 64mb")
 
 var fListen = flag.String("listen", "0.0.0.0:9224", "address to listen on")
 
@@ -55,7 +56,7 @@ func main() {
 	case *fRedis != "":
 		cache = templar.NewRedisCache(*fRedis, *fRedisPassword, *fExpire)
 	case *fGroupCacheThisPeer != "" && *fGroupCacheOtherPeers != "":
-		cache = templar.NewGroupCacheCache(*fGroupCacheThisPeer, *fGroupCacheOtherPeers, *fExpire, transport)
+		cache = templar.NewGroupCacheCache(*fGroupCacheThisPeer, *fGroupCacheOtherPeers, *fExpire, int64(*fGroupCacheMemoryLimit), transport)
 	case *fGroupCacheThisPeer != "" && *fGroupCacheOtherPeers == "":
 		panic(errors.New("templar: passed --groupcache-this-peer without passing --groupcache-other-peers. You have to set both of them to use the group cache backend"))
 	case *fGroupCacheThisPeer == "" && *fGroupCacheOtherPeers != "":

--- a/cmd/templar/templar.go
+++ b/cmd/templar/templar.go
@@ -18,6 +18,7 @@ var fExpire = flag.Duration("expire", 5*time.Minute, "how long to use cached val
 var fMemcache = flag.String("memcache", "", "memcache servers to use for caching")
 var fRedis = flag.String("redis", "", "redis server to use for caching")
 var fRedisPassword = flag.String("redis-password", "", "password to redis server")
+var fGroupCache = flag.String("groupcache", "", "groupcache peer url set to use for caching")
 
 var fListen = flag.String("listen", "0.0.0.0:9224", "address to listen on")
 
@@ -51,6 +52,8 @@ func main() {
 		cache = templar.NewMemcacheCache(strings.Split(*fMemcache, ":"), *fExpire)
 	case *fRedis != "":
 		cache = templar.NewRedisCache(*fRedis, *fRedisPassword, *fExpire)
+    case *fGroupCache != "":
+        cache = templar.NewGroupCacheCache(*fGroupCache, *fExpire)
 	default:
 		cache = templar.NewMemoryCache(*fExpire)
 	}


### PR DESCRIPTION
Hi,

This adds a backend that uses `groupcache`. It's not fully complete yet, but it does work (and I'd like feedback on the approach now that it's in code rather than just words).

This uses an key epoching scheme (as suggested by the groupcache github issues). This is because groupcache treats k/v pairs as immutable - a key should always be set for a given value. This means we have to do expiration manually, by changing keys.

This _does_ kinda suck for the case when you set templar as a fallback cache - it often will actually **re-request** the object from the source. It works great as an eager cache though. It is also somewhat bothersome that you can have objects fall out of cache _very_ quickly if you're near the end of the epoch.

Left to do:
- [ ] cache stats

Groupcache lets us get stats about the cache. We should probably expose these to the stats backends, but it's tricky knowing **when** to poll them, where to put the code etc (do we add a new interface in `interfaces.go` that takes a `CacheStats`?). Any thoughts here?
- [x] documentation

The README will need updating - there are a few caveats (especially around using templar as a fallback cache with groupcache).
