### PR TITLE
Better riemann events

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -68,6 +68,7 @@ func (r *RiemannOutput) StartRequest(req *http.Request) {
 	attributes["http-method"] = req.Method
 	attributes["http-host"] = req.Host
 	attributes["http-path"] = req.URL.Path
+	attributes["http-url"] = req.URL.String()
 	var event = &raidman.Event{
 		State:      "ok",
 		Service:    "templar request",
@@ -82,6 +83,7 @@ func (r *RiemannOutput) Emit(req *http.Request, delta time.Duration) {
 	attributes["http-method"] = req.Method
 	attributes["http-host"] = req.Host
 	attributes["http-path"] = req.URL.Path
+	attributes["http-url"] = req.URL.String()
 	var event = &raidman.Event{
 		State:      "ok",
 		Service:    "templar response",

--- a/stats.go
+++ b/stats.go
@@ -65,9 +65,9 @@ func NewRiemannOutput(client RiemannClient) *RiemannOutput {
 
 func (r *RiemannOutput) StartRequest(req *http.Request) {
 	attributes := make(map[string]string)
-	attributes["method"] = req.Method
+	attributes["http-method"] = req.Method
 	attributes["http-host"] = req.Host
-	attributes["path"] = req.URL.Path
+	attributes["http-path"] = req.URL.Path
 	var event = &raidman.Event{
 		State:      "ok",
 		Service:    "templar request",
@@ -79,9 +79,9 @@ func (r *RiemannOutput) StartRequest(req *http.Request) {
 
 func (r *RiemannOutput) Emit(req *http.Request, delta time.Duration) {
 	attributes := make(map[string]string)
-	attributes["method"] = req.Method
+	attributes["http-method"] = req.Method
 	attributes["http-host"] = req.Host
-	attributes["path"] = req.URL.Path
+	attributes["http-path"] = req.URL.Path
 	var event = &raidman.Event{
 		State:      "ok",
 		Service:    "templar response",

--- a/stats.go
+++ b/stats.go
@@ -66,7 +66,7 @@ func NewRiemannOutput(client RiemannClient) *RiemannOutput {
 func (r *RiemannOutput) StartRequest(req *http.Request) {
 	attributes := make(map[string]string)
 	attributes["method"] = req.Method
-	attributes["host"] = req.Host
+	attributes["http-host"] = req.Host
 	attributes["path"] = req.URL.Path
 	var event = &raidman.Event{
 		State:      "ok",
@@ -80,7 +80,7 @@ func (r *RiemannOutput) StartRequest(req *http.Request) {
 func (r *RiemannOutput) Emit(req *http.Request, delta time.Duration) {
 	attributes := make(map[string]string)
 	attributes["method"] = req.Method
-	attributes["host"] = req.Host
+	attributes["http-host"] = req.Host
 	attributes["path"] = req.URL.Path
 	var event = &raidman.Event{
 		State:      "ok",


### PR DESCRIPTION
1) prefix `host` with `http-`, to avoid removing information from the event about which server templar is running on
2) prefix all other custom attributes with `http-`
3) add a custom attribute that records `url` as well
